### PR TITLE
Finalize NPM publishing changes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+# npm dependencies
+node_modules/
+
+# source files, etc
+js/
+
+# git
+.github/
+
+# demo-only files
+demo.html
+demoApp.js
+rollup-demo.config.js
+dist/demoBundle.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a modernized fork of [patrickp-rthinfo/leaflet-color-markers](https://gi
 which is in turn a fork of [pointhi/leaflet-color-markers](https://github.com/pointhi/leaflet-color-markers).
 With this, the first commit to this project can be traced back to late 2013.
 
+Note that the Leaflet marker icon is [originally contributed to the Leaflet project](https://github.com/Leaflet/Leaflet/blob/main/src/images/marker.svg), and is not the work of this library. The work here is to make that marker icon available in more colors.
+
 ## Install
 
 (WIP)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const greenIcon = LCM.greenIcon;
 ### Preset Colors
 
 | Color | Marker | Color Inside | Color Outside |
-| ------------- |:-------------:|:-----:|:-----:|:-----:|
+| ------------- |:-----:|:-----:|:-----:|
 | Blue | ![Marker Blue](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-blue.png) | #2A81CB | #3274A3 |
 | Gold | ![Marker Gold](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-gold.png) | #FFD326 | #C1A32D |
 | Red | ![Marker Red](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-red.png) | #CB2B3E | #982E40 |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ Note that the Leaflet marker icon is [originally contributed to the Leaflet proj
 
 ## Install
 
-(WIP)
+via NPM:
+
+```
+npm install @vectorial1024/leaflet-color-markers
+```
+
+### Special Notice
+
+This library is a successor of [leaflet-color-markers](https://www.npmjs.com/package/leaflet-color-markers). That NPM library, for the lack of better words, actually does nothing.
 
 ## Demo
 
@@ -28,8 +36,7 @@ You may try it locally with the following steps:
 Add a simple marker using the green icon template to a Leaflet map: 
 
 ```javascript
-// to be tested, but theoretically should work
-import { greenIcon } from /* this library */;
+import { greenIcon } from "@vectorial1024/leaflet-color-markers";
 
 // we assume the map is already defined
 const map = L.map('theMap');
@@ -43,7 +50,7 @@ We recommend using the more modern ESM style (`import`) to handle dependencies, 
 
 ```javascript
 // require() also works, but we recommend using the import if possible
-const LCM = require(/* this library */);
+const LCM = require("@vectorial1024/leaflet-color-markers");
 const greenIcon = LCM.greenIcon;
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ With this, the first commit to this project can be traced back to late 2013.
 
 ## Demo
 
-A demo is included in the same repo. You may build it with the following steps:
+A demo is included in the same repo. It showcases a simple Leaflet map with a colored marker from this package.
+
+You may try it locally with the following steps:
 
 1. Clone this repo
 2. `npm run build-demo`

--- a/README.md
+++ b/README.md
@@ -47,20 +47,16 @@ const greenIcon = LCM.greenIcon;
 
 ## Colors
 
-(WIP)
+### Preset Colors
 
----
-
-color variations of the standard leaflet markers:
-
-| Color | Marker 2x  | Marker  | Color Inside | Color Outside |
+| Color | Marker | Color Inside | Color Outside |
 | ------------- |:-------------:|:-----:|:-----:|:-----:|
-| Blue | ![Marker Blue 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png) | ![Marker Blue](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png) | #2A81CB | #3274A3 |
-| Gold | ![Marker Gold 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-gold.png) | ![Marker Gold](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-gold.png) | #FFD326 | #C1A32D |
-| Red | ![Marker Red 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png) | ![Marker Red](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png) | #CB2B3E | #982E40 |
-| Green | ![Marker Green 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png) | ![Marker Green](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png) | #2AAD27 | #31882A |
-| Orange | ![Marker Orange 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-orange.png) | ![Marker Orange](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-orange.png) | #CB8427 | #98652E |
-| Yellow | ![Marker Yellow 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-yellow.png) | ![Marker Yellow](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-yellow.png) | #CAC428 | #988F2E |
-| Violet | ![Marker Violet 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-violet.png) | ![Marker Violet](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-violet.png) | #9C2BCB | #742E98 |
-| Grey | ![Marker Grey 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-grey.png) | ![Marker Grey](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-grey.png) | #7B7B7B | #6B6B6B |
-| Black | ![Marker Black 2x](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-black.png) | ![Marker Black](https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-black.png) | #3D3D3D | #313131 |
+| Blue | ![Marker Blue](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-blue.png) | #2A81CB | #3274A3 |
+| Gold | ![Marker Gold](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-gold.png) | #FFD326 | #C1A32D |
+| Red | ![Marker Red](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-red.png) | #CB2B3E | #982E40 |
+| Green | ![Marker Green](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-green.png) | #2AAD27 | #31882A |
+| Orange | ![Marker Orange](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-orange.png) | #CB8427 | #98652E |
+| Yellow | ![Marker Yellow](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-yellow.png) | #CAC428 | #988F2E |
+| Violet | ![Marker Violet](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-violet.png) | #9C2BCB | #742E98 |
+| Grey | ![Marker Grey](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-grey.png) | #7B7B7B | #6B6B6B |
+| Black | ![Marker Black](https://raw.githubusercontent.com/Vectorial1024/leaflet-color-markers/master/img/marker-icon-black.png) | #3D3D3D | #313131 |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "leaflet-color-markers",
+  "name": "@vectorial1024/leaflet-color-markers",
   "version": "2.0.0",
   "description": "The standard Leaflet marker icon, but in different color variations, for simple use cases.",
   "main": "dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "leaflet-color-markers",
   "version": "2.0.0",
   "description": "The standard Leaflet marker icon, but in different color variations, for simple use cases.",
-  "main": "js/index.js",
+  "main": "dist/bundle.js",
   "type": "module",
   "scripts": {
     "test": "exit 0",
+    "build": "rollup --config",
     "build-demo": "rollup --config rollup-demo.config.js"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,19 +13,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/patrickp-rthinfo/leaflet-color-markers.git"
+    "url": "git+https://github.com/Vectorial1024/leaflet-color-markers.git"
   },
   "keywords": [
-    "Leaflet",
-    "Maps",
-    "Marker"
+    "leaflet",
+    "maps",
+    "marker"
   ],
-  "author": "Thomas Pointhuber",
+  "author": "Vincent Wong",
   "license": "BSD-2-Clause",
   "bugs": {
-    "url": "https://github.com/patrickp-rthinfo/leaflet-color-markers/issues"
+    "url": "https://github.com/Vectorial1024/leaflet-color-markers/issues"
   },
-  "homepage": "https://github.com/patrickp-rthinfo/leaflet-color-markers#readme",
+  "homepage": "https://github.com/Vectorial1024/leaflet-color-markers#readme",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,11 +7,12 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import json from "@rollup/plugin-json";
 
 export default {
-	input: 'app.js',
+	input: 'js/index.js',
 	output: [
 		{
 			file: 'dist/bundle.js',
 			format: 'umd',
+            name: "LeafletColorMarkers"
 		}
 	],
     plugins: [


### PR DESCRIPTION
The library is now available at https://www.npmjs.com/package/@vectorial1024/leaflet-color-markers